### PR TITLE
Add module's exceptions: create exceptions.py and edit librus.py

### DIFF
--- a/py_librus_api/exceptions.py
+++ b/py_librus_api/exceptions.py
@@ -1,0 +1,5 @@
+class ConnectionError(Exception):
+    pass
+
+class UserNotLoggedInError(Exception):
+    pass

--- a/py_librus_api/librus.py
+++ b/py_librus_api/librus.py
@@ -1,5 +1,6 @@
 import requests
 import sys
+from . import exceptions
 
 
 class Librus:
@@ -68,15 +69,15 @@ class Librus:
                 return requests.get(self.host + "2.0/" + url, headers=self.headers)
             except (requests.exceptions.ConnectionError, TimeoutError, requests.exceptions.Timeout,
                     requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout):
-                    raise Exception("Connection error")
+                    raise exceptions.ConnectionError("Connection error")
         else:
-            raise Exception("User not logged in")
+            raise exceptions.UserNotLoggedInError("User not logged in")
 
     def get_lucky_number(self):
         if self.lucky_number is None:
             r = self.get_data("LuckyNumbers")
             self.lucky_number = r.json()["LuckyNumber"]["LuckyNumber"]
-            
+
             return self.lucky_number
 
         return self.lucky_number


### PR DESCRIPTION
If executing the method raises an exception stating that the user is not logged in, I can catch it like this:
```python
try:
    librus.get_grades()
exception Exception:
    print("Sorry! User not logged in!")
```
But I cannot be sure that this particular exception has occurred. It could also be a connection error. PEP-8 says you shouldn't catch normal `Exception` exceptions. So I suggest creating `py_librus_api/exceptions.py` file and adding `ConnectionError` and `UserNotLoggedInError` to it.  Than you can raise them instead of `Exception`. It seems to me that this should facilitate the work of people using this module.